### PR TITLE
size and fill icons equally

### DIFF
--- a/components/TripDisplay/TripDisplay.module.css
+++ b/components/TripDisplay/TripDisplay.module.css
@@ -10,7 +10,7 @@
 }
 
 .single_trip:active {
-  border: 4px solid #E2D784;
+  border: 4px solid #e2d784;
 }
 
 .single_trip_heading {
@@ -77,15 +77,17 @@
 
 .transportation_icon {
   padding: 4px;
-  /* background: #062c30;
-  border-radius: 40%;
- object-fit: fill; */
+  width: 24px;
+  height: 24px;
+  object-fit: contain;
 }
 
 .transportation_icon_container {
   z-index: 1;
   padding: 1px;
   display: flex;
+  align-items: center;
+  justify-content: center;
   background: #062c30;
   border-bottom-left-radius: 50% 25%;
   border-bottom-right-radius: 50% 25%;
@@ -279,6 +281,9 @@
   border-bottom-right-radius: 50% 25%;
   border-top-left-radius: 50% 25%;
   border-top-right-radius: 50% 25%;
+  width: 24px;
+  height: 28px;
+  object-fit: contain;
 }
 
 .circle_black {


### PR DESCRIPTION
Ich habe die Icons beim TripDisplay so angepasst, dass sie alle die gleiche Größe haben:

<img width="1096" alt="Bildschirm­foto 2023-02-26 um 19 52 09" src="https://user-images.githubusercontent.com/46243719/221430963-d275f1e5-1749-4d33-bb47-462867c8b024.png">

<img width="623" alt="Bildschirm­foto 2023-02-26 um 19 55 05" src="https://user-images.githubusercontent.com/46243719/221430955-f6daedf4-c504-469d-90e0-31e0cdeabb15.png">

